### PR TITLE
EdgeWallでツリーから出る時にシグナルを切断するように修正

### DIFF
--- a/edge_wall.gd
+++ b/edge_wall.gd
@@ -20,6 +20,9 @@ func _enter_tree() -> void:
 	get_viewport().size_changed.connect(_viewport_size_changed)
 	_viewport_size_changed()
 
+func _exit_tree() -> void:
+	get_viewport().size_changed.disconnect(_viewport_size_changed)
+
 func _viewport_size_changed() -> void:
 	_shape_top.distance = -get_viewport_rect().size.y / 2
 	_shape_bottom.distance = -get_viewport_rect().size.y / 2


### PR DESCRIPTION
EdgeWallがエディター内で複数回`connect()`してエラーが発生する問題があったため、ツリーから出る時に`size_changed`シグナルを切断するように修正。 Fix #6.