### PR TITLE
パイプの先端で、衝突形状の角が見た目と同じく丸くなるように

### DIFF
--- a/pipes/part.gd
+++ b/pipes/part.gd
@@ -9,28 +9,45 @@ extends StaticBody2D
 @export var texture_middle: Texture2D:
 	set(v): assert(v != null); texture_middle = v; queue_redraw()
 
-var _shape: RectangleShape2D = RectangleShape2D.new()
-var _shape_owner: int = -1
+var _base: CollisionShape2D = CollisionShape2D.new()
+var _top: CollisionShape2D = CollisionShape2D.new()
+var _corner_left: CollisionShape2D = CollisionShape2D.new()
+var _corner_right: CollisionShape2D = CollisionShape2D.new()
 
 func _init() -> void:
-	_shape_owner = create_shape_owner(self)
-	shape_owner_add_shape(_shape_owner, _shape)
+	_base.shape = RectangleShape2D.new()
+	add_child(_base, false, INTERNAL_MODE_BACK)
+	_top.shape = RectangleShape2D.new()
+	add_child(_top, false, INTERNAL_MODE_BACK)
+
+	var corner_shape := CircleShape2D.new()
+	corner_shape.radius = 14
+	_corner_left.shape = corner_shape
+	add_child(_corner_left, false, INTERNAL_MODE_BACK)
+	_corner_right.shape = corner_shape
+	add_child(_corner_right, false, INTERNAL_MODE_BACK)
 
 func _draw() -> void:
-	draw_texture(texture_top, Vector2(-_get_width()/2, -height))
+	assert(texture_top.get_width() == texture_middle.get_width())
+	var width := texture_top.get_width()
+
+	draw_texture(texture_top, Vector2(-width/2, -height))
 	draw_texture_rect(texture_middle, Rect2(
-		-_get_width()/2, -height + texture_top.get_height(),
+		-width/2, -height + texture_top.get_height(),
 		texture_middle.get_width(), maxf(0, height - texture_top.get_height()),
 	), true)
-	
-	shape_owner_set_transform(_shape_owner, Transform2D(0, Vector2(0, -height/2)))
-	_shape.size = Vector2(_get_width(), height)
-	
-	if get_tree().debug_collisions_hint or Engine.is_editor_hint():
-		var color := ProjectSettings.get_setting("debug/shapes/collision/shape_color")
-		draw_set_transform_matrix(shape_owner_get_transform(_shape_owner))
-		_shape.draw(get_canvas_item(), color)
 
-func _get_width() -> float:
-	assert(texture_top.get_width() == texture_middle.get_width())
-	return texture_top.get_width()
+	#region Collision shapes
+	var corner_radius := (_corner_left.shape as CircleShape2D).radius
+
+	_base.set_deferred("disabled", height <= corner_radius)
+	if height > corner_radius:
+		_base.position.y = (-height + corner_radius) / 2
+		(_base.shape as RectangleShape2D).size = Vector2(width, height - corner_radius)
+	_top.position.y = -height + corner_radius/2
+	(_top.shape as RectangleShape2D).size = Vector2(width - corner_radius*2, corner_radius)
+
+	var corner_y := -height + corner_radius
+	_corner_left.position = Vector2(-width/2 + corner_radius, corner_y)
+	_corner_right.position = Vector2(width/2 - corner_radius, corner_y)
+	#endregion


### PR DESCRIPTION
Fix #36

<img height="150" alt="image" src="https://github.com/user-attachments/assets/7425727e-25b2-4c7b-a440-493977341e41" />

完璧ですね👍